### PR TITLE
[Fix] - ZStack을 활용하여 필터에 맞는 결과가 없을 시 Text를 출력

### DIFF
--- a/Raon/Raon/Views/SearchViews/SearchView.swift
+++ b/Raon/Raon/Views/SearchViews/SearchView.swift
@@ -8,95 +8,108 @@
 import SwiftUI
 
 struct SearchView: View {
-    // MARK: - @State Properties
-    @State private var searchText = String()
-    @State private var isPresented = false
-    @State private var categoryFilter: Categories = .allCategory
-    @State private var regionFilter: Regions = .allRegion
+  // MARK: - @State Properties
+  @State private var searchText = String()
+  @State private var isPresented = false
+  @State private var categoryFilter: Categories = .allCategory
+  @State private var regionFilter: Regions = .allRegion
 
-    // MARK: - @Binding Properties
-    @Binding var contents: [ProgramContentModel]
-    @Binding var themeColor: ThemeColors
-    @Binding var searchPath: [DestinationPath]
+  // MARK: - @Binding Properties
+  @Binding var contents: [ProgramContentModel]
+  @Binding var themeColor: ThemeColors
+  @Binding var searchPath: [DestinationPath]
 
-    // MARK: - Body
-    var body: some View {
-        NavigationStack(path: $searchPath) {
-            ScrollViewReader { proxy in
-                List {
-                    EmptyView()
-                        .id("firstView")
-                    ForEach(getFilteredContents(), id: \.title) { content in
-                        NavigationLink(value: DestinationPath.detail(content)) {
-                            SearchCardView(content: content)
-                        }
-                    }
-                }
-                .listStyle(.plain)
-                .scrollIndicators(.hidden)
-                .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        NavigationBarSmallTitleView(
-                            titleText: "검색",
-                            themeColor: themeColor)
-                    }
+  // MARK: - Body
+  var body: some View {
+    let filteredContents = getFilteredContents()
 
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button("SearchFilter", systemImage: "slider.horizontal.3") {
-                            isPresented.toggle()
-                        }
-                        .sheet(isPresented: $isPresented) {
-                            FilterView(
-                                categoryFilter: $categoryFilter,
-                                regionFilter: $regionFilter)
-                            .presentationDetents([.height(250)])
-                            .presentationDragIndicator(.visible)
-                            .presentationCornerRadius(30)
-                        }
-                    }
-                }
-                .navigationDestination(for: DestinationPath.self, destination: { destination in
-                    if case .detail(let content) = destination {
-                        ProgramDetailView(themeColor: $themeColor, content: content)
-                    }
-                })
-                .searchable(
-                    text: $searchText,
-                    placement: .navigationBarDrawer(displayMode: .always),
-                    prompt: "프로그램명을 입력해주세요")
-                .onChange(of: categoryFilter) {
-                    proxy.scrollTo("firstView", anchor: .bottom)
-                }
-                .onChange(of: regionFilter) {
-                    proxy.scrollTo("firstView", anchor: .bottom)
-                }
+    NavigationStack(path: $searchPath) {
+      ScrollViewReader { proxy in
+        ZStack {
+          if filteredContents.isEmpty {
+            VStack {
+              Text("해당 필터에 맞는 결과가 없습니다")
+                .foregroundStyle(.secondary)
+                .font(.headline)
             }
+          } else {
+            List {
+              EmptyView()
+                .id("firstView")
+              ForEach(filteredContents, id: \.title) { content in
+                NavigationLink(value: DestinationPath.detail(content)) {
+                  SearchCardView(content: content)
+                }
+              }
+            }
+          }
         }
-    }
-
-    // MARK: - Private Functions
-    private func getFilteredContents() -> [ProgramContentModel] {
-        if searchText.isEmpty {
-            contents.filter {
-                if categoryFilter != .allCategory && regionFilter != .allRegion {
-                    return $0.category == categoryFilter.rawValue && $0.region == regionFilter.rawValue
-                } else if categoryFilter != .allCategory {
-                    return $0.category == categoryFilter.rawValue
-                } else if regionFilter != .allRegion {
-                    return $0.region == regionFilter.rawValue
-                } else {
-                    return true
-                }
+        .listStyle(.plain)
+        .scrollIndicators(.hidden)
+        .toolbar {
+          ToolbarItem(placement: .topBarLeading) {
+            NavigationBarSmallTitleView(
+              titleText: "검색",
+              themeColor: themeColor)
+          }
+          ToolbarItem(placement: .topBarTrailing) {
+            Button("SearchFilter", systemImage: "slider.horizontal.3") {
+              isPresented.toggle()
             }
+            .sheet(isPresented: $isPresented) {
+              FilterView(
+                categoryFilter: $categoryFilter,
+                regionFilter: $regionFilter)
+              .presentationDetents([.height(250)])
+              .presentationDragIndicator(.visible)
+              .presentationCornerRadius(30)
+            }
+          }
+        }
+        .navigationDestination(for: DestinationPath.self, destination: { destination in
+          if case .detail(let content) = destination {
+            ProgramDetailView(themeColor: $themeColor, content: content)
+          }
+        })
+        .searchable(
+          text: $searchText,
+          placement: .navigationBarDrawer(displayMode: .always),
+          prompt: "프로그램명을 입력해주세요")
+        .onChange(of: categoryFilter) {
+          guard !filteredContents.isEmpty else { return }
+          proxy.scrollTo("firstView", anchor: .bottom)
+        }
+        .onChange(of: regionFilter) {
+          guard !filteredContents.isEmpty else { return }
+          proxy.scrollTo("firstView", anchor: .bottom)
+        }
+      }
+    }
+  }
+
+  // MARK: - Private Functions
+  private func getFilteredContents() -> [ProgramContentModel] {
+    if searchText.isEmpty {
+      contents.filter {
+        if categoryFilter != .allCategory && regionFilter != .allRegion {
+          return $0.category == categoryFilter.rawValue && $0.region == regionFilter.rawValue
+        } else if categoryFilter != .allCategory {
+          return $0.category == categoryFilter.rawValue
+        } else if regionFilter != .allRegion {
+          return $0.region == regionFilter.rawValue
         } else {
-            contents.filter { $0.title.localizedStandardContains(searchText) }
+          return true
         }
+      }
+    } else {
+      contents.filter { $0.title.localizedStandardContains(searchText) }
     }
+  }
 }
 
 #Preview {
-    SearchView(
-        contents: .constant(NetworkManager().contents),
-        themeColor: .constant(.pink),
-        searchPath: .constant([]))
+  SearchView(
+    contents: .constant(NetworkManager().contents),
+    themeColor: .constant(.pink),
+    searchPath: .constant([]))
 }


### PR DESCRIPTION
< 문제 >
- 검색 탭에서 필터를 적용할 때 해당 결과가 아무것도 없다면 크래시 발생

< 해결 >
- getFilteredContents를 filteredContents에 할당하고, 그 값의 isEmpty 여부에 따라 보여지는 View 분기 처리
- 1) filteredContents가 비어있을 경우: Text를 사용하여 해당 필터에 맞는 결과가 없다는 View를 표현
- 2) filteredContents가 비어있지 않을 경우: 기존과 마찬가지로 해당 필터가 적용된 List를 표현