### PR TITLE
[Fix] #20 설정의 알림 토글 비정상적 동작 해결

### DIFF
--- a/Raon/Raon/Managers/NotificationManager.swift
+++ b/Raon/Raon/Managers/NotificationManager.swift
@@ -67,8 +67,12 @@ final class NotificationManager: ObservableObject {
 
     func setNotificationStatus() {
         center.getNotificationSettings { [weak self] settings in
-            DispatchQueue.main.async {
-                self?.notificationStatus = settings.authorizationStatus == .authorized
+            let isAuthorized = settings.authorizationStatus == .authorized
+
+            if self?.notificationStatus != isAuthorized {
+                DispatchQueue.main.async {
+                    self?.notificationStatus = isAuthorized
+                }
             }
         }
     }

--- a/Raon/Raon/Views/SettingsViews/NotificationToggleView.swift
+++ b/Raon/Raon/Views/SettingsViews/NotificationToggleView.swift
@@ -15,26 +15,27 @@ struct NotificationToggleView: View {
     // MARK: - @State Properties
     @State private var isAlertPresented: Bool = false
 
-    // MARK: - @Binding Properties
-    @Binding var isToggleOn: Bool
+    // MARK: - Private Properties
+    /// 토글과 바인딩을 커스터마이징하여 값 변경을 막고 알림 표시하는 프로퍼티
+    private var bindingForToggle: Binding<Bool> {
+        Binding<Bool>(
+            get: { notificationManager.notificationStatus },
+            set: { _ in
+                isAlertPresented = true
+            }
+        )
+    }
 
     // MARK: - Body
     var body: some View {
-        Toggle(isOn: $isToggleOn, label: {
+        Toggle(isOn: bindingForToggle, label: {
             Label("알림", systemImage: "bell")
         })
         .onAppear(perform: {
-            DispatchQueue.main.async {
-                notificationManager.setNotificationStatus()
-            }
+            notificationManager.setNotificationStatus()
         })
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-            DispatchQueue.main.async {
-                notificationManager.setNotificationStatus()
-            }
-        }
-        .onTapGesture {
-            isAlertPresented.toggle()
+            notificationManager.setNotificationStatus()
         }
         .alert(isPresented: $isAlertPresented) {
             Alert(
@@ -45,17 +46,14 @@ struct NotificationToggleView: View {
 
                     UIApplication.shared.open(settingsURL)
                 }),
-                secondaryButton: .cancel(Text("닫기"), action: {
-                    DispatchQueue.main.async {
-                        notificationManager.setNotificationStatus()
-                    }
-                }))
+                secondaryButton: .cancel(Text("닫기"))
+            )
         }
     }
 }
 
 
 #Preview {
-    NotificationToggleView(isToggleOn: .constant(false))
+    NotificationToggleView()
         .environmentObject(NotificationManager())
 }

--- a/Raon/Raon/Views/SettingsViews/SettingsView.swift
+++ b/Raon/Raon/Views/SettingsViews/SettingsView.swift
@@ -8,9 +8,6 @@
 import SwiftUI
 
 struct SettingsView: View {
-    // MARK: - @EnvironmentObject Properties
-    @EnvironmentObject var notificationManager: NotificationManager
-
     // MARK: - @Binding Properties
     @Binding var themeColor: ThemeColors
     @Binding var selectedRegion: Regions
@@ -46,7 +43,7 @@ struct SettingsView: View {
                 .listRowSeparator(.hidden)
 
                 Section {
-                    NotificationToggleView(isToggleOn: $notificationManager.notificationStatus)
+                    NotificationToggleView()
 
                     ThemeSettingView(themeColor: $themeColor)
 


### PR DESCRIPTION
- 앱 권한과 동기화되지 않고 앱 내에서 자체적으로 On/Off 토글할 수 있는 문제 해결
- notificationManager의 setNotificationStatus 메서드 최적화: 기존에는 무조건 bool값을 notificationStatus에 할당했지만 if문을 사용하여 같지 않을 때만 할당하는 것으로 변경